### PR TITLE
Cuphead - Fix Entry Splitting

### DIFF
--- a/Cuphead/Cuphead.asl
+++ b/Cuphead/Cuphead.asl
@@ -117,7 +117,7 @@ init
 		var lvl = mono.GetClass("Level");
 
 		// vars.Helper["lvl2"] = lvl.Make<int>("Current", "CurrentLevel");
-		vars.Helper["lvl"] = lvl.Make<int>("PreviousLevel");
+		// vars.Helper["lvl"] = lvl.Make<int>("PreviousLevel");
 		vars.Helper["lvlTime"] = lvl.Make<float>("Current", "LevelTime");
 		vars.Helper["lvlDifficulty"] = lvl.Make<int>("Current", "mode");
 		vars.Helper["lvlEnding"] = lvl.Make<bool>("Current", "Ending");
@@ -128,6 +128,7 @@ init
 		var sl = mono.GetClass("SceneLoader");
 
 		vars.Helper["sceneName"] = sl.MakeString("SceneName");
+		vars.Helper["lvl"] = sl.Make<int>("CurrentLevel");
 		vars.Helper["doneLoading"] = sl.Make<bool>("_instance", "doneLoadingSceneAsync");
 		#endregion // SceneLoader
 


### PR DESCRIPTION
SBDWolf mentioned to you in the speedrun tools dev discord that we had an issue with the ASL splitting level entry. This patch has been tested by quite a few people to fix that issue (making this ASL work perfectly for patch 1.3.2 afaik).

The value used to identify the level is currently `Level.PreviousLevel`. When you enter a level it is still the previous level (i.e. has the id of the previous level entered) for a brief moment before switching to the current one (the one we are now in), and in that brief moment it checks the completion flag of the previous level, which is true in certain cases (if the last level you entered marked itself as completed, not true for some), then splits accordingly.

I found a better value at `SceneLoader.CurrentLevel` (switches the current level as soon as it is selected in the overworld). It never makes this false check.

I understand that the old autosplitter also used `Level.PreviousLevel` (or at least claims to), so I'm not sure what exactly happened there, but it's working.

Thanks