### PR TITLE
Cuphead - Fix IL timing issues

### DIFF
--- a/Cuphead/Cuphead.asl
+++ b/Cuphead/Cuphead.asl
@@ -264,7 +264,7 @@ split
 
 			case "ilEnd":
 			{
-				if (current.Time > 0f && current.IsEnding)
+				if (current.Time > 0f && current.HasWon)
 					return true;
 
 				continue;

--- a/Cuphead/Cuphead.asl
+++ b/Cuphead/Cuphead.asl
@@ -176,6 +176,12 @@ update
 
 start
 {
+	// ilEnter should also start the timer
+	if(settings["ilEnter"] && old.Time == 0f && current.Time > 0f)
+	{
+		return true;
+	}
+
 	return current.Scene == "scene_cutscene_intro" && current.InGame && current.Loading;
 }
 


### PR DESCRIPTION
The old splitter didn't start properly on level enter, and split too early for Run 'n Gun levels. This patch includes a section in the start clause & uses the correct value to detect the end of levels (`HasWon` instead of `Ending`).