### PR TITLE
Cuphead - Some bug fixes

### DIFF
--- a/Cuphead/Cuphead.Splits.xml
+++ b/Cuphead/Cuphead.Splits.xml
@@ -10,56 +10,56 @@
 	<!-- Sort of guessing the chalice tutorial level name, long story short our current mod has some issues regarding that tutorial level and it doesn't display properly -->
 	<Split ID="scene_level_chalice_tutorial" Name="Chalice Tutorial (Level)" ToolTip="Splits when leaving the Chalice Tutorial level" Type="SCENE_LEAVE"/>
 
-	<Split ID="scene_level_veggies"      Name="The Root Pack (Boss)"    ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE"/>
-	<Split ID="scene_level_slime"        Name="Goopy Le Grande (Boss)"  ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE"/>
-	<Split ID="scene_level_flower"       Name="Cagney Carnation (Boss)" ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE"/>
-	<Split ID="scene_level_frogs"        Name="Ribby And Croaks (Boss)" ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE"/>
-	<Split ID="scene_level_flying_blimp" Name="Hilda Berg (Boss)"       ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE"/>
+	<Split ID="scene_level_veggies"      Name="The Root Pack (Boss)"    ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="6"/>
+	<Split ID="scene_level_slime"        Name="Goopy Le Grande (Boss)"  ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1450863107"/>
+	<Split ID="scene_level_flower"       Name="Cagney Carnation (Boss)" ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1450266910"/>
+	<Split ID="scene_level_frogs"        Name="Ribby And Croaks (Boss)" ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="7"/>
+	<Split ID="scene_level_flying_blimp" Name="Hilda Berg (Boss)"       ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1449745424"/>
 
-	<Split ID="scene_level_baroness"     Name="Baroness Von Bon Bon (Boss)" ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE"/>
-	<Split ID="scene_level_flying_genie" Name="Djimmi The Great (Boss)"     ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE"/>
-	<Split ID="scene_level_clown"        Name="Beppi The Clown (Boss)"      ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE"/>
-	<Split ID="scene_level_flying_bird"  Name="Wally Warbles (Boss)"        ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE"/>
-	<Split ID="scene_level_dragon"       Name="Grim Matchstick (Boss)"      ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE"/>
+	<Split ID="scene_level_baroness"     Name="Baroness Von Bon Bon (Boss)" ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1451300935"/>
+	<Split ID="scene_level_flying_genie" Name="Djimmi The Great (Boss)"     ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1460200177"/>
+	<Split ID="scene_level_clown"        Name="Beppi The Clown (Boss)"      ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1456125457"/>
+	<Split ID="scene_level_flying_bird"  Name="Wally Warbles (Boss)"        ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1428495827"/>
+	<Split ID="scene_level_dragon"       Name="Grim Matchstick (Boss)"      ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1432722919"/>
 
-	<Split ID="scene_level_bee"              Name="Rumor Honeybottoms (Boss)" ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE"/>
-	<Split ID="scene_level_pirate"           Name="Captin Brineybeard (Boss)" ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE"/>
-	<Split ID="scene_level_mouse"            Name="Werner Werman (Boss)"      ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE"/>
-	<Split ID="scene_level_robot"            Name="Dr. Kahl's Robot (Boss)"   ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE"/>
-	<Split ID="scene_level_sally_stage_play" Name="Sally Stageplay (Boss)"    ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE"/>
-	<Split ID="scene_level_flying_mermaid"   Name="Cala Maria (Boss)"         ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE"/>
-	<Split ID="scene_level_train"            Name="Phantom Express (Boss)"    ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE"/>
+	<Split ID="scene_level_bee"              Name="Rumor Honeybottoms (Boss)" ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1429976377"/>
+	<Split ID="scene_level_pirate"           Name="Captin Brineybeard (Boss)" ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="2"/>
+	<Split ID="scene_level_mouse"            Name="Werner Werman (Boss)"      ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1430652919"/>
+	<Split ID="scene_level_robot"            Name="Dr. Kahl's Robot (Boss)"   ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1452935394"/>
+	<Split ID="scene_level_sally_stage_play" Name="Sally Stageplay (Boss)"    ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1456740288"/>
+	<Split ID="scene_level_flying_mermaid"   Name="Cala Maria (Boss)"         ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1446558823"/>
+	<Split ID="scene_level_train"            Name="Phantom Express (Boss)"    ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="5"/>
 
-	<Split ID="scene_level_old_man"       Name="Glumstone The Giant (Boss)" ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE"/>
-	<Split ID="scene_level_snow_cult"     Name="Mortimer Freeze (Boss)"     ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE"/>
-	<Split ID="scene_level_airplane"      Name="The Howling Aces (Boss)"    ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE"/>
-	<Split ID="scene_level_flying_cowboy" Name="Esther Winchester (Boss)"   ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE"/>
-	<Split ID="scene_level_rum_runners"   Name="Moonshine Mob (Boss)"       ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE"/>
-	<Split ID="scene_level_saltbaker"     Name="Chef Saltbaker (Boss)"      ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE"/>
-	<Split ID="scene_level_graveyard"     Name="Demon and Angel (Boss)"     ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE"/>
+	<Split ID="scene_level_old_man"       Name="Glumstone The Giant (Boss)" ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1523429320"/>
+	<Split ID="scene_level_snow_cult"     Name="Mortimer Freeze (Boss)"     ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1527591209"/>
+	<Split ID="scene_level_airplane"      Name="The Howling Aces (Boss)"    ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1511943573"/>
+	<Split ID="scene_level_flying_cowboy" Name="Esther Winchester (Boss)"   ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1530096313"/>
+	<Split ID="scene_level_rum_runners"   Name="Moonshine Mob (Boss)"       ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1518081307"/>
+	<Split ID="scene_level_saltbaker"     Name="Chef Saltbaker (Boss)"      ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1573044456"/>
+	<Split ID="scene_level_graveyard"     Name="Demon and Angel (Boss)"     ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1616405510"/>
 
 	<Split ID="scene_cutscene_kingdice"      Name="King Dice (Contract Cutscene)" ToolTip="Splits when you get the cutscene trying to enter the King Dice fight without all contracts" Type="SCENE_ENTER"/>
-	<Split ID="scene_level_dice_palace_main" Name="King Dice (Boss)"              ToolTip="Splits when you beat King Dice"                                                             Type="LEVEL_COMPLETE"/>
-	<Split ID="scene_level_devil"            Name="Devil (Boss)"                  ToolTip="Splits when level is finished"                                                              Type="LEVEL_COMPLETE"/>
+	<Split ID="scene_level_dice_palace_main" Name="King Dice (Boss)"              ToolTip="Splits when you beat King Dice"                                                             Type="LEVEL_COMPLETE" Level="1465296077"/>
+	<Split ID="scene_level_devil"            Name="Devil (Boss)"                  ToolTip="Splits when level is finished"                                                              Type="LEVEL_COMPLETE" Level="1466688317"/>
 
 	<Split ID="scene_cutscene_credits" Name="End Game (Credits)" ToolTip="Splits when entering the credits" Type="SCENE_ENTER"/>
 
-	<Split ID="scene_level_platforming_1_1F" Name="Forest Follies (Run 'n Gun)"   ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE"/>
-	<Split ID="scene_level_platforming_1_2F" Name="Treetop Trouble (Run 'n Gun)"  ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE"/>
-	<Split ID="scene_level_platforming_2_1F" Name="Funfair Fever (Run 'n Gun)"    ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE"/>
-	<Split ID="scene_level_platforming_2_2F" Name="Funhouse Frazzle (Run 'n Gun)" ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE"/>
-	<Split ID="scene_level_platforming_3_1F" Name="Perilous Piers (Run 'n Gun)"   ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE"/>
-	<Split ID="scene_level_platforming_3_2F" Name="Rugged Ridge (Run 'n Gun)"     ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE"/>
+	<Split ID="scene_level_platforming_1_1F" Name="Forest Follies (Run 'n Gun)"   ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1464969490"/>
+	<Split ID="scene_level_platforming_1_2F" Name="Treetop Trouble (Run 'n Gun)"  ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1464969491"/>
+	<Split ID="scene_level_platforming_2_1F" Name="Funfair Fever (Run 'n Gun)"    ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1499704951"/>
+	<Split ID="scene_level_platforming_2_2F" Name="Funhouse Frazzle (Run 'n Gun)" ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1496818712"/>
+	<Split ID="scene_level_platforming_3_1F" Name="Perilous Piers (Run 'n Gun)"   ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1464969492"/>
+	<Split ID="scene_level_platforming_3_2F" Name="Rugged Ridge (Run 'n Gun)"     ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1464969493"/>
 
 	<Split ID="scene_level_mausoleum_0" Name="Mausoleum I (Super)"   ToolTip="Splits when level is finished" Type="ENDING"/>
 	<Split ID="scene_level_mausoleum_1" Name="Mausoleum II (Super)"  ToolTip="Splits when level is finished" Type="ENDING"/>
 	<Split ID="scene_level_mausoleum_2" Name="Mausoleum III (Super)" ToolTip="Splits when level is finished" Type="ENDING"/>
 
-	<Split ID="scene_level_chess_pawn"   Name="Chess Pawns (Boss)"  ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE"/>
-	<Split ID="scene_level_chess_knight" Name="Chess Knight (Boss)" ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE"/>
-	<Split ID="scene_level_chess_bishop" Name="Chess Bishop (Boss)" ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE"/>
-	<Split ID="scene_level_chess_rook"   Name="Chess Rook (Boss)"   ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE"/>
-	<Split ID="scene_level_chess_queen"  Name="Chess Queen (Boss)"  ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE"/>
+	<Split ID="scene_level_chess_pawn"   Name="Chess Pawns (Boss)"  ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1562078899"/>
+	<Split ID="scene_level_chess_knight" Name="Chess Knight (Boss)" ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1560339521"/>
+	<Split ID="scene_level_chess_bishop" Name="Chess Bishop (Boss)" ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1526556188"/>
+	<Split ID="scene_level_chess_rook"   Name="Chess Rook (Boss)"   ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1560855325"/>
+	<Split ID="scene_level_chess_queen"  Name="Chess Queen (Boss)"  ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1561124831"/>
 
 	<Split ID="ilEnter" Name="Enter Level (IL)" ToolTip="Splits when entering any level" Type="CUSTOM"/>
 	<Split ID="ilEnd"   Name="End Level (IL)"   ToolTip="Splits when ending any level"   Type="CUSTOM"/>

--- a/Cuphead/Cuphead.asl
+++ b/Cuphead/Cuphead.asl
@@ -9,6 +9,7 @@ startup
 	vars.Helper = Activator.CreateInstance(type, timer, this);
 
 	vars.Splits = new Dictionary<string, string>();
+	vars.SceneLevels = new Dictionary<string, int>();
 
 	settings.Add("splits", true, "Splits:");
 
@@ -22,6 +23,8 @@ startup
 		settings.SetToolTip(id, tt);
 
 		vars.Splits[id] = splitType;
+		if(splitType == "LEVEL_COMPLETE")
+			vars.SceneLevels[id] = int.Parse(split.Attribute("Level").Value);
 	}
 
 	vars.Helper.AlertLoadless("Cuphead");
@@ -211,6 +214,8 @@ update
 	if (current.InKingDice != old.InKingDice) vars.Log("InKingDice:     " +     current.InKingDice);
 	if (current.InKingDiceMain != old.InKingDiceMain) vars.Log("InKingDiceMain:     " +     current.InKingDiceMain);
 	if (current.IsKDLevelEnding != old.IsKDLevelEnding) vars.Log("IsKDLevelEnding:     " +     current.IsKDLevelEnding);
+	if (current.Level != old.Level) vars.Log("Level:     " +     current.Level);
+	if (current.Scene != old.Scene) vars.Log("Scene:     " +     current.Scene);
 	
 	// vars.Log("Level:      " +      current.Level);
 	// vars.Log("InGame:     " +     current.InGame);
@@ -274,9 +279,11 @@ split
 
 			case "LEVEL_COMPLETE":
 			{
-				if (current.Scene == id && vars.IsLevelCompleted(current.Level, -1, -1))
+				if (current.Scene == id 
+				    && vars.SceneLevels.ContainsKey(id) && current.Level == vars.SceneLevels[id]
+				    && vars.IsLevelCompleted(current.Level, -1, -1))
 				{
-					vars.Log("LEVEL_COMPLETE | " + id + " in " + current.Time + " on " + current.Difficulty);
+					vars.Log("LEVEL_COMPLETE | " + id + " in " + current.Time);
 
 					vars.CompletedSplits.Add(id);
 					return true;

--- a/Cuphead/Cuphead.asl
+++ b/Cuphead/Cuphead.asl
@@ -39,16 +39,7 @@ onStart
 }
 
 onSplit
-{
-	// Set final split's time to accurate in-game time when player is doing IL attempts.
-	// This (like `reset`) assumes the runner only has 1 split.
-	// DevilSquirrel's code. /shrug
-	if (timer.CurrentPhase != TimerPhase.Ended || timer.Run.Count != 1)
-		return;
-
-	var time = timer.Run[0].SplitTime;
-	timer.Run[0].SplitTime = new Time(time.RealTime, TimeSpan.FromSeconds(current.Time));
-}
+{}
 
 onReset
 {}

--- a/Cuphead/Cuphead.asl
+++ b/Cuphead/Cuphead.asl
@@ -195,7 +195,18 @@ update
 		vars.Helper.Timer.Reset();
 	}
 
-	// KD nonsense
+	/* King Dice consists of several levels. The game gets the final time for the boss by summing
+	 * the level times of each of these. Every time a level finishes, it appends the current.Time to the current.LSDTime.
+	 * 
+	 * If we are in a miniboss (i.e. InKingDiceMain is false), the time is updated when the boss is defeated. This syncs with
+	 * HasWon from false -> true and IsEnding from false -> true (when ilEnd would fire). current.Time also freezes.
+	 * 
+	 * If we are InKingDiceMain, then time is updated briefly after the space on the board is selected (and we are transitioning
+	 * into a boss). HasWon and IsEnding are not updated, and current.Time doesn't freeze.
+	 * 
+	 * So to check if a level is ending we check if the LSDTime is updated (and isn't being reset).
+	 * We set this value back to false when we transition from the main palace to a miniboss or vica-versa (the next level has started).
+	*/
 	if (current.InKingDiceMain != old.InKingDiceMain)
 	{
 		current.IsKDLevelEnding = false;
@@ -206,17 +217,6 @@ update
 		current.IsKDLevelEnding = true;
 	}
 
-	if (current.Loading != old.Loading) vars.Log("Loading:     " +     current.Loading);
-	if (current.HasWon != old.HasWon) vars.Log("HasWon:     " +     current.HasWon);
-	if (current.IsEnding != old.IsEnding) vars.Log("IsEnding:     " +     current.IsEnding);
-	if (current.Time != old.Time && current.Time == 0) vars.Log("Time reset from " + old.Time);
-	if (current.LSDTime != old.LSDTime) vars.Log("LSDTime:     " +     current.LSDTime);
-	if (current.InKingDice != old.InKingDice) vars.Log("InKingDice:     " +     current.InKingDice);
-	if (current.InKingDiceMain != old.InKingDiceMain) vars.Log("InKingDiceMain:     " +     current.InKingDiceMain);
-	if (current.IsKDLevelEnding != old.IsKDLevelEnding) vars.Log("IsKDLevelEnding:     " +     current.IsKDLevelEnding);
-	if (current.Level != old.Level) vars.Log("Level:     " +     current.Level);
-	if (current.Scene != old.Scene) vars.Log("Scene:     " +     current.Scene);
-	
 	// vars.Log("Level:      " +      current.Level);
 	// vars.Log("InGame:     " +     current.InGame);
 	// vars.Log("Time:       " +       current.Time);
@@ -361,17 +361,9 @@ gameTime
 	{
 		if (!current.InKingDice)
 			return TimeSpan.FromSeconds(current.Time);
-
-		/*
-		King Dice consists of several levels. The game gets the final time for the boss by summing
-		the level times of each of these. Every time a level finishes, it appends the current.Time to the current.LSDTime.
-
-		If we are in a miniboss (i.e. InKingDiceMain is false), the time is updated when the boss is defeated. This syncs with
-		HasWon from false -> true and IsEnding from false -> true (when ilEnd would fire). Time also stops updating.
-
-		If we are InKingDiceMain, then time is updated briefly after the space on the board is selected (and we are transitioning
-		into a boss). HasWon and IsEnding are not updated, and current.Time continues counting.
-		*/
+		
+		// King dice is a series of levels whose time at the end is a sum of all levels.
+		// If a level is ending we just use that time, otherwise we update the current time with the current level time
 		var time = current.IsKDLevelEnding ? current.LSDTime : current.LSDTime + current.Time;
 		return TimeSpan.FromSeconds(time);
 	}

--- a/Cuphead/Cuphead.asl
+++ b/Cuphead/Cuphead.asl
@@ -45,7 +45,9 @@ onSplit
 {}
 
 onReset
-{}
+{
+	current.IsKDLevelEnding = false;
+}
 
 init
 {

--- a/Cuphead/Cuphead.asl
+++ b/Cuphead/Cuphead.asl
@@ -356,16 +356,16 @@ reset
 
 gameTime
 {
-	if (current.InILMode)
-	{
-		if (!current.InKingDice)
-			return TimeSpan.FromSeconds(current.Time);
-		
-		// King dice is a series of levels whose time at the end is a sum of all levels, updated after each level is completed.
-		// If a level is ending we just use that time, otherwise we update the current time with the current level time
-		var time = current.IsKDLevelEnding ? current.LSDTime : current.LSDTime + current.Time;
-		return TimeSpan.FromSeconds(time);
-	}
+	if (!current.InILMode)
+		return;
+
+	if (!current.InKingDice)
+		return TimeSpan.FromSeconds(current.Time);
+	
+	// King dice is a series of levels whose time at the end is a sum of all levels, updated after each level is completed.
+	// If a level is ending we just use that time, otherwise we update the current time with the current level time
+	var time = current.IsKDLevelEnding ? current.LSDTime : current.LSDTime + current.Time;
+	return TimeSpan.FromSeconds(time);
 }
 
 isLoading

--- a/Cuphead/Cuphead.asl
+++ b/Cuphead/Cuphead.asl
@@ -71,6 +71,10 @@ init
 		vars.GetCurrentSave = (Func<IntPtr>)(() =>
 		{
 			var slot = vars.Helper["saveSlotIndex"].Current;
+
+			if (vars.Helper["saveFiles"].Current.Length < 2)
+				return IntPtr.Zero;
+
 			return vars.Helper["saveFiles"].Current[slot];
 		});
 
@@ -164,9 +168,11 @@ update
 	if (!vars.Helper.Update())
 		return false;
 
-	current.InILMode = settings["ilEnter"] && settings["ilEnd"] && timer.Run.Count == 1;
-
 	current.SaveSlot = vars.GetCurrentSave();
+	if (current.SaveSlot == IntPtr.Zero)
+		return false;
+
+	current.InILMode = settings["ilEnter"] && settings["ilEnd"] && timer.Run.Count == 1;
 
 	current.Loading = !vars.Helper["doneLoading"].Current;
 	current.Scene = vars.Helper["sceneName"].Current;

--- a/Cuphead/Cuphead.asl
+++ b/Cuphead/Cuphead.asl
@@ -344,9 +344,7 @@ split
 
 reset
 {
-	if (current.InILMode && (current.InOverworld
-	   || !current.InKingDice && current.Loading && current.Time == 0f
-	   || current.InKingDice && current.Loading && current.LSDTime == 0f))
+	if (current.InILMode && (current.Loading && current.LSDTime == 0f || current.InOverworld))
 	{
 		vars.Log("Resetting due to reset {} | Time: " + current.Time + " | InOverworld: " + current.InOverworld + " | InKingDice: " + current.InKingDice + " | Loading: " + current.Loading);
 		current.IsKDLevelEnding = false;

--- a/Cuphead/Cuphead.asl
+++ b/Cuphead/Cuphead.asl
@@ -363,6 +363,17 @@ gameTime
 		var time = current.IsKDLevelEnding ? current.LSDTime : current.LSDTime + current.Time;
 		return TimeSpan.FromSeconds(time);
 	}
+	
+	// Sometimes the time is 0.01 during the first loading screen, it should always be 0, so we force that here
+	// https://discord.com/channels/144133978759233536/144134231201808385/727009875569279048
+	if(timer.CurrentTime.GameTime.HasValue
+	    && current.Loading
+		&& timer.CurrentTime.GameTime.Value > TimeSpan.Zero
+	    && timer.CurrentTime.RealTime.Value < TimeSpan.FromMilliseconds(50))
+	{
+		vars.Log("Overwriting game time to 0 | RealTime: " + timer.CurrentTime.RealTime.Value + " | GameTime: " + timer.CurrentTime.GameTime.Value);
+		return TimeSpan.Zero;
+	}
 }
 
 isLoading

--- a/Cuphead/Cuphead.asl
+++ b/Cuphead/Cuphead.asl
@@ -84,7 +84,9 @@ init
 
 		vars.GetAllLevelsData = (Func<List<dynamic>>)(() =>
 		{
-			var levels = vars.Helper.ReadList<IntPtr>(current.SaveSlot + pd["levelDataManager"], pldm["levelObjects"]);
+			// pldm["levelObjects"] sometimes causes a Sequence contains no matching element error in MonoClass[int]
+			// don't know why, it seems random, but it's always 0x10 anyways
+			var levels = vars.Helper.ReadList<IntPtr>(current.SaveSlot + pd["levelDataManager"], 0x10);
 			var ret = new List<dynamic>();
 
 			foreach (var level in levels)

--- a/Cuphead/Cuphead.asl
+++ b/Cuphead/Cuphead.asl
@@ -76,7 +76,7 @@ init
 		// Level Completion
 		var pldm = mono.GetClass("PlayerLevelDataManager");
 		var pldo = mono.GetClass("PlayerLevelDataObject");
-		if(pldm.Fields.Count == 0 || pldo.Fields.Count == 0)
+		if (pldm.Fields.Count == 0 || pldo.Fields.Count == 0)
 			return false;
 
 		vars.GetAllLevelsData = (Func<List<dynamic>>)(() =>

--- a/Cuphead/Cuphead.asl
+++ b/Cuphead/Cuphead.asl
@@ -358,7 +358,7 @@ gameTime
 		if (!current.InKingDice)
 			return TimeSpan.FromSeconds(current.Time);
 		
-		// King dice is a series of levels whose time at the end is a sum of all levels.
+		// King dice is a series of levels whose time at the end is a sum of all levels, updated after each level is completed.
 		// If a level is ending we just use that time, otherwise we update the current time with the current level time
 		var time = current.IsKDLevelEnding ? current.LSDTime : current.LSDTime + current.Time;
 		return TimeSpan.FromSeconds(time);

--- a/Cuphead/Cuphead.asl
+++ b/Cuphead/Cuphead.asl
@@ -344,12 +344,11 @@ split
 
 reset
 {
-	if (current.InILMode && (
-	      !current.InKingDice && current.Loading && current.Time == 0f
-	   || current.InKingDice && current.Loading && current.LSDTime == 0f
-	   || current.InOverworld))
+	if (current.InILMode && (current.InOverworld
+	   || !current.InKingDice && current.Loading && current.Time == 0f
+	   || current.InKingDice && current.Loading && current.LSDTime == 0f))
 	{
-		vars.Log("Resetting due to reset {} | Time: " + current.Time + " | Loading: " + current.Loading + " | InOverworld: " + current.InOverworld);
+		vars.Log("Resetting due to reset {} | Time: " + current.Time + " | InOverworld: " + current.InOverworld + " | InKingDice: " + current.InKingDice + " | Loading: " + current.Loading);
 		current.IsKDLevelEnding = false;
 		return true;
 	}


### PR DESCRIPTION
This patch fixes:
- The King Dice (Boss) split. (used wrong level completion flag) (major issue). This is the reason the xml includes Level ids now. The level ID updated after the scene which meant it was checking the previous level's completion flag, now it checks that the level ID is what is expected.
- King Dice for IL timing (needs to use some special cases)
- 0.01 on first loading screen (using some jank, might be an asl thing, I don't know)
- `onSplit` is no longer necessary since we use `gameTime` now (and was causing some unintended behavior previously as it wasn't using `inILMode`)
- `pldm["levelObjects"]` sometimes gave a "Sequence contains no matching element" error (don't know how to reproduce this consistently), so it was simply replaced with `0x10` which is it's offset in every version of Cuphead. [link](https://github.com/just-ero/asl/compare/main...mitchell-merry:asl:kd#diff-8aa7e17a7bec8b9d8fa90e103c30b4685b55a4664cb6c5c69e53bc510ff64b97L80). It might be worth changing the .First in MonoClass[int] to .FirstOrDefault so that we can check for null and coalesce it to a default value if necessary.
- No save slots exists before the orange intro screen which produced a lot of errors, now it just returns a null pointer and returns false in update in this case.

Thank you