### PR TITLE
Cuphead - Additional Settings

### DIFF
--- a/Cuphead/Cuphead.Splits.xml
+++ b/Cuphead/Cuphead.Splits.xml
@@ -22,13 +22,13 @@
 	<Split ID="scene_level_flying_bird"  Name="Wally Warbles (Boss)"        ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1428495827"/>
 	<Split ID="scene_level_dragon"       Name="Grim Matchstick (Boss)"      ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1432722919"/>
 
-	<Split ID="scene_level_bee"              Name="Rumor Honeybottoms (Boss)" ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1429976377"/>
-	<Split ID="scene_level_pirate"           Name="Captin Brineybeard (Boss)" ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="2"/>
-	<Split ID="scene_level_mouse"            Name="Werner Werman (Boss)"      ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1430652919"/>
-	<Split ID="scene_level_robot"            Name="Dr. Kahl's Robot (Boss)"   ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1452935394"/>
-	<Split ID="scene_level_sally_stage_play" Name="Sally Stageplay (Boss)"    ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1456740288"/>
-	<Split ID="scene_level_flying_mermaid"   Name="Cala Maria (Boss)"         ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1446558823"/>
-	<Split ID="scene_level_train"            Name="Phantom Express (Boss)"    ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="5"/>
+	<Split ID="scene_level_bee"              Name="Rumor Honeybottoms (Boss)"  ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1429976377"/>
+	<Split ID="scene_level_pirate"           Name="Captain Brineybeard (Boss)" ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="2"/>
+	<Split ID="scene_level_mouse"            Name="Werner Werman (Boss)"       ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1430652919"/>
+	<Split ID="scene_level_robot"            Name="Dr. Kahl's Robot (Boss)"    ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1452935394"/>
+	<Split ID="scene_level_sally_stage_play" Name="Sally Stageplay (Boss)"     ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1456740288"/>
+	<Split ID="scene_level_flying_mermaid"   Name="Cala Maria (Boss)"          ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1446558823"/>
+	<Split ID="scene_level_train"            Name="Phantom Express (Boss)"     ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="5"/>
 
 	<Split ID="scene_level_old_man"       Name="Glumstone The Giant (Boss)" ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1523429320"/>
 	<Split ID="scene_level_snow_cult"     Name="Mortimer Freeze (Boss)"     ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1527591209"/>

--- a/Cuphead/Cuphead.Splits.xml
+++ b/Cuphead/Cuphead.Splits.xml
@@ -60,7 +60,4 @@
 	<Split ID="scene_level_chess_bishop" Name="Chess Bishop (Boss)" ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1526556188"/>
 	<Split ID="scene_level_chess_rook"   Name="Chess Rook (Boss)"   ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1560855325"/>
 	<Split ID="scene_level_chess_queen"  Name="Chess Queen (Boss)"  ToolTip="Splits when level is finished" Type="LEVEL_COMPLETE" Level="1561124831"/>
-
-	<Split ID="ilEnter" Name="Enter Level (IL)" ToolTip="Splits when entering any level" Type="CUSTOM"/>
-	<Split ID="ilEnd"   Name="End Level (IL)"   ToolTip="Splits when ending any level"   Type="CUSTOM"/>
 </Splits>

--- a/Cuphead/Cuphead.asl
+++ b/Cuphead/Cuphead.asl
@@ -244,7 +244,11 @@ start
 		return true;
 	}
 
-	return current.Scene == "scene_cutscene_intro" && current.InGame && current.Loading;
+	if (current.Scene == "scene_cutscene_intro" && current.InGame && current.Loading)
+	{
+		vars.Log("Starting due to save select | InGame: " + current.InGame + " | Loading: " + current.Loading);
+		return true;
+	}
 }
 
 split

--- a/Cuphead/Cuphead.asl
+++ b/Cuphead/Cuphead.asl
@@ -11,9 +11,18 @@ startup
 	vars.Splits = new Dictionary<string, string>();
 	vars.SceneLevels = new Dictionary<string, int>();
 
+	vars.Grades = new string[] { "D-", "D", "D+", "C-", "C", "C+", "B-", "B", "B+", "A-", "A", "A+", "S", "P" };
+	vars.Difficulties = new string[] { "Simple", "Regular", "Expert" };
+
+	vars.BossHG = new int[] { 8, 11, 12 }; // B+, A+, S for Simple, Regular, Expert
+	vars.PRank = 13;
+	
 	settings.Add("ilmode", false, "Use IL timer?");
 	settings.SetToolTip("ilmode", "Must have 'Splits' unchecked and only 1 split in 'Edit Splits'.");
 
+	settings.Add("highest_grade", false, "Only split on highest grade.");
+	settings.SetToolTip("highest_grade", "Only splits on levels with grades when they have been completed with grade S or P. Does not affect IL mode.");
+	
 	settings.Add("splits", true, "Splits:");
 
 	var xml = System.Xml.Linq.XDocument.Load(@"Components\Cuphead.Splits.xml");

--- a/Cuphead/Cuphead.asl
+++ b/Cuphead/Cuphead.asl
@@ -268,6 +268,15 @@ start
 
 split
 {
+	if(current.InILMode)
+	{
+		if ((current.InKingDice && !current.InKingDiceMain) || current.Time == 0f || !current.HasWon)
+			return false;
+
+		vars.Log("Splitting due to IL End | Time: " + current.Time + " | HasWon: " + current.HasWon);
+		return true;
+	}
+
 	foreach (var split in vars.Splits)
 	{
 		string id = split.Key, type = split.Value;

--- a/Cuphead/Cuphead.asl
+++ b/Cuphead/Cuphead.asl
@@ -305,9 +305,10 @@ split
 
 			case "LEVEL_COMPLETE":
 			{
+				var targetGrade = settings["highest_grade"] ? current.HighestGrade : -1;
 				if (current.Scene == id 
 				    && vars.SceneLevels.ContainsKey(id) && current.Level == vars.SceneLevels[id]
-				    && vars.IsLevelCompleted(current.Level, -1, -1))
+				    && vars.IsLevelCompleted(current.Level, -1, targetGrade))
 				{
 					vars.Log("LEVEL_COMPLETE | " + id + " in " + current.Time);
 

--- a/Cuphead/Cuphead.asl
+++ b/Cuphead/Cuphead.asl
@@ -270,7 +270,7 @@ split
 {
 	if(current.InILMode)
 	{
-		if ((current.InKingDice && !current.InKingDiceMain) || current.Time == 0f || !current.HasWon)
+		if ((current.InKingDice && (!current.InKingDiceMain || !current.IsKDLevelEnding)) || current.Time == 0f || !current.HasWon)
 			return false;
 
 		vars.Log("Splitting due to IL End | Time: " + current.Time + " | HasWon: " + current.HasWon);

--- a/Cuphead/Cuphead.asl
+++ b/Cuphead/Cuphead.asl
@@ -24,7 +24,7 @@ startup
 	settings.SetToolTip("ilTimeLoadless", "Use loadless time (reflecting real runs) instead of the timer in-game. Includes pauses / parries and loads on King Dice.");
 
 	settings.Add("highest_grade", false, "Only split on highest grade.");
-	settings.SetToolTip("highest_grade", "Only splits on levels with grades when they have been completed with grade S or P. Does not affect IL mode.");
+	settings.SetToolTip("highest_grade", "Only splits on levels with grades when they have been completed with highest grade for difficulty (B+, A+, S, or P). Does not affect IL mode.");
 	
 	settings.Add("splits", true, "Splits:");
 

--- a/Cuphead/Cuphead.asl
+++ b/Cuphead/Cuphead.asl
@@ -16,7 +16,7 @@ startup
 
 	vars.BossHG = new int[] { 8, 11, 12 }; // B+, A+, S for Simple, Regular, Expert
 	vars.PRank = 13;
-	
+
 	settings.Add("ilMode", false, "Use IL timer?");
 	settings.SetToolTip("ilMode", "Must have 'Splits' unchecked and only 1 split in 'Edit Splits'.");
 
@@ -25,7 +25,7 @@ startup
 
 	settings.Add("highest_grade", false, "Only split on highest grade.");
 	settings.SetToolTip("highest_grade", "Only splits on levels with grades when they have been completed with highest grade for difficulty (B+, A+, S, or P). Does not affect IL mode.");
-	
+
 	settings.Add("splits", true, "Splits:");
 
 	var xml = System.Xml.Linq.XDocument.Load(@"Components\Cuphead.Splits.xml");
@@ -147,14 +147,11 @@ init
 		var lvl = mono.GetClass("Level");
 		var lsd = mono.GetClass("LevelScoringData");
 
-		// vars.Helper["lvl2"] = lvl.Make<int>("Current", "CurrentLevel");
-		// vars.Helper["lvl"] = lvl.Make<int>("PreviousLevel");
+		vars.Helper["lvlType"] = lvl.Make<int>("Current", "type");
 		vars.Helper["lvlTime"] = lvl.Make<float>("Current", "LevelTime");
 		vars.Helper["lvlDifficulty"] = lvl.Make<int>("Current", "mode");
 		vars.Helper["lvlEnding"] = lvl.Make<bool>("Current", "Ending");
 		vars.Helper["lvlWon"] = lvl.Make<bool>("Won");
-		// Battle, Tutorial, Platforming
-		vars.Helper["lvlType"] = lvl.Make<int>("Current", "type");
 
 		vars.Helper["lvlIsDicePalace"] = lvl.Make<bool>("IsDicePalace");
 		vars.Helper["lvlIsDicePalaceMain"] = lvl.Make<bool>("IsDicePalaceMain");
@@ -169,8 +166,6 @@ init
 		vars.Helper["lvl"] = sl.Make<int>("CurrentLevel");
 		vars.Helper["doneLoading"] = sl.Make<bool>("_instance", "doneLoadingSceneAsync");
 		#endregion // SceneLoader
-
-
 
 		return true;
 	});
@@ -204,9 +199,11 @@ update
 	current.Difficulty = vars.Helper["lvlDifficulty"].Current;
 	current.IsEnding = vars.Helper["lvlEnding"].Current;
 	current.HasWon = vars.Helper["lvlWon"].Current;
+
+	// Battle=0 (B+/A+/S), Tutorial=1 (N/A), Platforming=2 (P)
 	current.Type = vars.Helper["lvlType"].Current;
-	current.HighestGrade = 
-	    current.Type == 0 ? vars.BossHG[current.Difficulty] : 
+	current.HighestGrade =
+	    current.Type == 0 ? vars.BossHG[current.Difficulty] :
 	    current.Type == 2 ? vars.PRank : -1;
 
 	if (current.Scene == "scene_win")
@@ -241,16 +238,6 @@ update
 	{
 		current.IsKDLevelEnding = true;
 	}
-
-	// vars.Log("Level:      " +      current.Level);
-	// vars.Log("InGame:     " +     current.InGame);
-	// vars.Log("Time:       " +       current.Time);
-	// vars.Log("Difficulty: " + current.Difficulty);
-	// vars.Log("IsEnding:   " +   current.IsEnding);
-	// vars.Log("HasWon:     " +     current.HasWon);
-	// vars.Log("Loading:    " +    current.Loading);
-	// vars.Log("Scene:      " +      current.Scene);
-	// vars.Log("---------------------------------");
 }
 
 start

--- a/Cuphead/Cuphead.asl
+++ b/Cuphead/Cuphead.asl
@@ -17,8 +17,11 @@ startup
 	vars.BossHG = new int[] { 8, 11, 12 }; // B+, A+, S for Simple, Regular, Expert
 	vars.PRank = 13;
 	
-	settings.Add("ilmode", false, "Use IL timer?");
-	settings.SetToolTip("ilmode", "Must have 'Splits' unchecked and only 1 split in 'Edit Splits'.");
+	settings.Add("ilMode", false, "Use IL timer?");
+	settings.SetToolTip("ilMode", "Must have 'Splits' unchecked and only 1 split in 'Edit Splits'.");
+
+	settings.Add("ilTimeLoadless", false, "Use Loadless time instead of IGT?", "ilMode");
+	settings.SetToolTip("ilTimeLoadless", "Use loadless time (reflecting real runs) instead of the timer in-game. Includes pauses / parries and loads on King Dice.");
 
 	settings.Add("highest_grade", false, "Only split on highest grade.");
 	settings.SetToolTip("highest_grade", "Only splits on levels with grades when they have been completed with grade S or P. Does not affect IL mode.");
@@ -184,7 +187,7 @@ update
 	if (current.SaveSlot == IntPtr.Zero)
 		return false;
 
-	current.InILMode = settings["ilmode"] && !settings["splits"] && timer.Run.Count == 1;
+	current.InILMode = settings["ilMode"] && !settings["splits"] && timer.Run.Count == 1;
 
 	current.Loading = !vars.Helper["doneLoading"].Current;
 	current.Scene = vars.Helper["sceneName"].Current;
@@ -358,7 +361,7 @@ reset
 
 gameTime
 {
-	if (!current.InILMode)
+	if (!current.InILMode || settings["ilTimeLoadless"])
 		return;
 
 	if (!current.InKingDice)
@@ -372,7 +375,7 @@ gameTime
 
 isLoading
 {
-	return current.InILMode || current.Loading;
+	return (current.InILMode && !settings["ilTimeLoadless"]) || current.Loading;
 }
 
 exit

--- a/Cuphead/Cuphead.asl
+++ b/Cuphead/Cuphead.asl
@@ -150,6 +150,8 @@ init
 		vars.Helper["lvlDifficulty"] = lvl.Make<int>("Current", "mode");
 		vars.Helper["lvlEnding"] = lvl.Make<bool>("Current", "Ending");
 		vars.Helper["lvlWon"] = lvl.Make<bool>("Won");
+		// Battle, Tutorial, Platforming
+		vars.Helper["lvlType"] = lvl.Make<int>("Current", "type");
 
 		vars.Helper["lvlIsDicePalace"] = lvl.Make<bool>("IsDicePalace");
 		vars.Helper["lvlIsDicePalaceMain"] = lvl.Make<bool>("IsDicePalaceMain");
@@ -199,6 +201,10 @@ update
 	current.Difficulty = vars.Helper["lvlDifficulty"].Current;
 	current.IsEnding = vars.Helper["lvlEnding"].Current;
 	current.HasWon = vars.Helper["lvlWon"].Current;
+	current.Type = vars.Helper["lvlType"].Current;
+	current.HighestGrade = 
+	    current.Type == 0 ? vars.BossHG[current.Difficulty] : 
+	    current.Type == 2 ? vars.PRank : -1;
 
 	if (current.Scene == "scene_win")
 		current.Scene = old.Scene;

--- a/Cuphead/Cuphead.asl
+++ b/Cuphead/Cuphead.asl
@@ -11,6 +11,9 @@ startup
 	vars.Splits = new Dictionary<string, string>();
 	vars.SceneLevels = new Dictionary<string, int>();
 
+	settings.Add("ilmode", false, "Use IL timer?");
+	settings.SetToolTip("ilmode", "Must have 'Splits' unchecked and only 1 split in 'Edit Splits'.");
+
 	settings.Add("splits", true, "Splits:");
 
 	var xml = System.Xml.Linq.XDocument.Load(@"Components\Cuphead.Splits.xml");
@@ -170,7 +173,7 @@ update
 	if (current.SaveSlot == IntPtr.Zero)
 		return false;
 
-	current.InILMode = settings["ilEnter"] && settings["ilEnd"] && timer.Run.Count == 1;
+	current.InILMode = settings["ilmode"] && !settings["splits"] && timer.Run.Count == 1;
 
 	current.Loading = !vars.Helper["doneLoading"].Current;
 	current.Scene = vars.Helper["sceneName"].Current;
@@ -305,38 +308,6 @@ split
 					vars.Log("ENDING | " + id);
 
 					vars.CompletedSplits.Add(id);
-					return true;
-				}
-
-				continue;
-			}
-		}
-
-		// case "CUSTOM"
-		switch (id)
-		{
-			case "ilEnter":
-			{
-				if (current.InKingDice && old.InKingDice)
-					continue;
-					
-				if (old.Time == 0f && current.Time > 0f)
-				{
-					vars.Log("Splitting due to IL Enter | Time: " + old.Time + " -> " + current.Time);
-					return true;
-				}
-
-				continue;
-			}
-
-			case "ilEnd":
-			{
-				if (current.InKingDice && !current.InKingDiceMain)
-					continue;
-
-				if (current.Time > 0f && current.HasWon)
-				{
-					vars.Log("Splitting due to IL End | Time: " + current.Time + " | HasWon: " + current.HasWon);
 					return true;
 				}
 

--- a/Cuphead/Cuphead.asl
+++ b/Cuphead/Cuphead.asl
@@ -170,7 +170,7 @@ init
 		vars.Helper["doneLoading"] = sl.Make<bool>("_instance", "doneLoadingSceneAsync");
 		#endregion // SceneLoader
 
-		var x = mono.GetClass("PlayerStatsManager");
+
 
 		return true;
 	});


### PR DESCRIPTION
- Extract the IL mode to a single setting and remove Enter/End Level (those didn't make sense with the asl's boolean setting system, nor really in the original one).
- Add setting for Highest Grade-only splitting (For categories like Hater%/All S+P where you only want to split if the level just completed was completed with the highest grade. I have never seen anybody use any setting for this than Any / Highest grade in the original autosplitter)
- Sub-option for IL mode to use the loadless time instead of taking IGT.
  - IGT doesn't count things like parries (lag frames) and the game being paused, so it is inadequate for full game run practice in certain cases (~10 second discrepancy for some fights)
  - RTA is a good solution for most bosses, but King Dice has loads during it's fight so this option is mainly targeted towards that.

Also some cheeky bug fixes/typos:
- "Captin Brineybeard" -> "Capt**a**in Brineybeard" (not your fault, was like this for the original autosplitter)
- The first miniboss on king dice uniquely caused the timer to reset and start again when transitioning back to main (not noticeable if you use IGT, but for RTA use it's breaking)