### PR TITLE
Sonic Project 06: Add splits on level section change

### DIFF
--- a/Sonic Project '06/SonicProject06.asl
+++ b/Sonic Project '06/SonicProject06.asl
@@ -7,6 +7,7 @@ startup
   vars.Helper.LoadSceneManager = true;
 
   vars.Helper.AlertLoadless();
+  settings.Add("sectionSplit", false, "Split on section change");
 }
 
 onStart
@@ -49,7 +50,8 @@ start
 
 split
 {
-  return old.State == 2 && current.State == 5
+
+  return (old.State == 2 && current.State == 5) || (settings["sectionSplit"] && current.Level != old.Level && current.Level != "MainMenu" && old.Level != "MainMenu" && old.state != 0)
     /* || old.CheckPoint != current.CheckPoint && settings[current.CheckPoint] */;
 }
 

--- a/Sonic Project '06/SonicProject06.asl
+++ b/Sonic Project '06/SonicProject06.asl
@@ -50,8 +50,8 @@ start
 
 split
 {
-
-  return (old.State == 2 && current.State == 5) || (settings["sectionSplit"] && current.Level != old.Level && current.Level != "MainMenu" && old.Level != "MainMenu" && old.state != 0)
+  return old.State == 2 && current.State == 5
+    || settings["sectionSplit"] && old.Level != current.Level && old.Level != "MainMenu" && current.Level != "MainMenu" && current.State != 0
     /* || old.CheckPoint != current.CheckPoint && settings[current.CheckPoint] */;
 }
 

--- a/Sonic Project '06/SonicProject06.asl
+++ b/Sonic Project '06/SonicProject06.asl
@@ -6,8 +6,8 @@ startup
   vars.Helper.GameName = "Sonic Project '06";
   vars.Helper.LoadSceneManager = true;
 
-  vars.Helper.AlertLoadless();
   settings.Add("sectionSplit", false, "Split on section change");
+  vars.Helper.AlertLoadless();
 }
 
 onStart

--- a/Sonic Project '06/SonicProject06.asl
+++ b/Sonic Project '06/SonicProject06.asl
@@ -7,6 +7,7 @@ startup
   vars.Helper.LoadSceneManager = true;
 
   settings.Add("sectionSplit", false, "Split on section change");
+
   vars.Helper.AlertLoadless();
 }
 


### PR DESCRIPTION
This patch adds a toggleable split when changing sections mid level, done by checking for level ID changes. 
Checks are added to prevent splitting when entering/leaving main menu, as that is also a change in level ID. The check is a little bloated, but its the only way I could find to consistently prevent erroneous splits, not too sure why.